### PR TITLE
Add Lotofacil runner and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ source .env/bin/activate  # Linux/Mac
 pip install -r requirements.txt
 ```
 
-3. Configure o arquivo `configv3.json` conforme necessário (um exemplo é fornecido)
+3. Configure o arquivo `configv3.json` (Mega-Sena) ou `config_lotofacil.json` conforme necessário (exemplos já incluídos)
 
 ## Uso
 
@@ -80,6 +80,14 @@ O programa irá:
 4. Gerar previsões para o próximo sorteio
 5. Criar visualizações
 6. Exportar resultados em Excel
+
+### Lotofácil
+Para executar a versão adaptada para Lotofácil utilize:
+```bash
+python run_lotofacil.py
+```
+O script irá rodar `lotofacil.py` e, ao final, exibir a previsão mais recente
+registrada em `output_lotofacil/lotofacil_v3.log`.
 
 ## Otimização de Hiperparâmetros
 
@@ -128,20 +136,24 @@ mega_sena/
 ├── mega_sena_v3.py      # Script principal
 ├── hyperparameter_tuning.py # Módulo de otimização de hiperparâmetros
 ├── configv3.json        # Configurações do modelo
+├── lotofacil.py         # Versão adaptada para Lotofácil
+├── config_lotofacil.json # Configurações da Lotofácil
 ├── run_mega_sena.py     # Script para execução via terminal
+├── run_lotofacil.py     # Script para execução da Lotofácil
 ├── run_mega_sena.bat    # Script para execução via Windows
 ├── setup_env.bat        # Script para configurar ambiente virtual
 ├── requirements.txt     # Dependências do projeto
 ├── README.md            # Este arquivo
 ├── .env/                # Ambiente virtual Python
 ├── output/              # Diretório para arquivos de saída
+├── output_lotofacil/    # Diretório para saídas da Lotofácil
 ├── cache/               # Diretório para cache de dados
 └── logs/                # Diretório para logs do TensorBoard
 ```
 
 ## Configuração
 
-O arquivo `configv3.json` permite ajustar vários parâmetros:
+Os arquivos `configv3.json` (Mega-Sena) e `config_lotofacil.json` (Lotofácil) permitem ajustar vários parâmetros:
 
 ```json
 {

--- a/run_lotofacil.py
+++ b/run_lotofacil.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Execute o modelo de previsão da Lotofácil de forma simples."""
+
+import os
+import sys
+import subprocess
+import argparse
+
+
+def show_last_prediction(log_file):
+    """Imprime a última previsão registrada no log da Lotofácil."""
+    if not os.path.exists(log_file):
+        print(f"Log não encontrado: {log_file}")
+        return
+    with open(log_file, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    start = None
+    for idx in range(len(lines) - 1, -1, -1):
+        if "PREVISÃO LOTOFÁCIL - PRÓXIMO SORTEIO" in lines[idx]:
+            start = idx
+            break
+    if start is None:
+        print("Não foi possível localizar a previsão no log.")
+        return
+    print("\n===== Previsão do próximo sorteio (Lotofácil) =====")
+    for line in lines[start:]:
+        line = line.strip()
+        print(line)
+        if "AVISO CRÍTICO" in line:
+            break
+    print("===================================================\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Executa o modelo da Lotofácil e exibe a previsão final."
+    )
+    parser.add_argument(
+        "--config", default="config_lotofacil.json", help="Arquivo de configuração."
+    )
+    args = parser.parse_args()
+
+    output_dir = "output_lotofacil"
+    os.makedirs(output_dir, exist_ok=True)
+    log_file = os.path.join(output_dir, "lotofacil_v3.log")
+
+    cmd = [sys.executable, "lotofacil.py"]
+    if args.config:
+        cmd += (
+            ["--config", args.config]
+            if "--config" in open("lotofacil.py").read()
+            else cmd
+        )
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"ERRO ao executar Lotofácil: {e}")
+        sys.exit(1)
+
+    # Exibe a previsão que foi registrada no log
+    show_last_prediction(log_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_lotofacil.py` script to execute Lotofácil version and show the last predicted draw
- document how to run the Lotofácil version
- list Lotofácil files in project structure
- mention both configuration files

## Testing
- `pytest -q`
- `black run_lotofacil.py`

------
https://chatgpt.com/codex/tasks/task_e_6847709c82f88329a9246366b79b2667